### PR TITLE
fix drag&drop example

### DIFF
--- a/Chapters/Morphic/Morphic.pillar
+++ b/Chapters/Morphic/Morphic.pillar
@@ -571,7 +571,7 @@ receiver; here it will stay attached to the mouse pointer:
 DroppedMorph >> rejectDropMorphEvent: anEvent
 	| h |
 	h := anEvent hand.
-	WorldState addDeferredUIMessage: [ h grabMorph: self ].
+	Smalltalk currentWorld worldState defer: [ h grabMorph: self ].
 	anEvent wasHandled: true
 ]]]
 

--- a/Chapters/Morphic/Morphic.pillar
+++ b/Chapters/Morphic/Morphic.pillar
@@ -571,7 +571,7 @@ receiver; here it will stay attached to the mouse pointer:
 DroppedMorph >> rejectDropMorphEvent: anEvent
 	| h |
 	h := anEvent hand.
-	Smalltalk currentWorld worldState defer: [ h grabMorph: self ].
+	self currentWorld worldState defer: [ h grabMorph: self ].
 	anEvent wasHandled: true
 ]]]
 


### PR DESCRIPTION
While working on a Bloc version of this chapter, I noticed the drag&drop example in Morphic was broken. This simple change fix it.