### PR TITLE
Fix book name by removing superfluous file extension

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
   build:
     uses: SquareBracketAssociates/BookBuilderDashboard/.github/workflows/main.yml@newVersionOfPillar
     with:
-      bookname: PharoByExample9.pdf
+      bookname: PharoByExample9


### PR DESCRIPTION
The workflow adds the `.pdf` extension to the name of the generated file, so this is duplicated and results in 

`PharoByExample9.pdf.pdf`